### PR TITLE
Save to collection

### DIFF
--- a/app/controllers/weather_music_controller.rb
+++ b/app/controllers/weather_music_controller.rb
@@ -10,4 +10,8 @@ class WeatherMusicController < ApplicationController
   get "/weather_playlist" do
     serialization(WeatherService.new.forecast(params[:q]), params[:token])
   end
+
+  post "/add_playlist_to_library" do
+    playlist(params[:q], params[:main_description], params[:user_id], params[:tracks], params[:token])
+  end
 end

--- a/app/serializers/playlist_serializer.rb
+++ b/app/serializers/playlist_serializer.rb
@@ -1,0 +1,23 @@
+class PlaylistSerializer
+
+  def initialize(status, external_url)
+    @status = status
+    @external_url = external_url
+  end
+
+  def data_hash
+    {
+      data:
+      {
+        playlist: {
+          type: 'playlist',
+          attributes: {
+            status: @status.as_json,
+            external_url: @external_url.as_json
+          }
+        }
+      }
+    }
+  end
+
+end


### PR DESCRIPTION
Add endpoint functionality for creating a new playlist for a user and filling that playlist with 20 educated guess tracks based on the music. This endpoint is only hit if the user clicks the save to collection link on the dashboard.

Files changed:
new endpoint.route in the weather_music controller that handles params
method in the application controller that handles the service calls'
two post requests to spotify for creating and filling a playlist. 
serialization of the response including external url and status